### PR TITLE
Hide Sponsor tab on archived years

### DIFF
--- a/templates/components/navigation.html
+++ b/templates/components/navigation.html
@@ -9,7 +9,9 @@
         <li><a href="/{{ year_dir }}/about">About</a></li>
         <li><a href="/{{ year_dir }}/schedule">Schedule</a></li>
         <li><a href="/{{ year_dir }}/speakers">Speakers</a></li>
+        {% if viewing_current_year %}
         <li><a href="/{{ year_dir }}/sponsor">Sponsor</a></li>
+        {% endif %}
         {% if not viewing_current_year %}
         <li><a href="/{{ current_year }}/">{{ current_year }} →</a></li>
         {% endif %}


### PR DESCRIPTION
## Summary

The Sponsor tab was 404'ing on `/2025/*` pages because no `content/2025/sponsor.md` exists (the sponsorship prospectus is a 2026-onwards concept; we're not back-filling 2025). Scope the nav link to the current year only.

## Test plan

- [ ] Visit `/2025/about` and confirm the nav has no "Sponsor" tab
- [ ] Visit `/2026/about` and confirm the nav still shows "Sponsor" pointing at `/2026/sponsor`