### PR TITLE
Add 2026 Closure Tier sponsors (Flox, Protectli) and link the prospectus

### DIFF
--- a/content/2026/_index.md
+++ b/content/2026/_index.md
@@ -57,7 +57,8 @@ deployment for supporting the Nix Community at DEF CON:
 >[![Flox](/img/sponsors/Flox.svg)](https://flox.dev)
 >[![Protectli](/img/sponsors/Protectli.png)](https://protectli.com/)
 
-Interested in sponsoring us with hardware, funding, or something else?
-Connect with us at <sponsor@nix.vegas>.
+Interested in sponsoring us with hardware, funding, or something else? See the
+[Sponsorship Prospectus](/2026/sponsor) and connect with us at
+<sponsor@nix.vegas>.
 
 Note that all emails to us go to a shared mailbox and ticketing system now.

--- a/content/2026/_index.md
+++ b/content/2026/_index.md
@@ -49,6 +49,14 @@ can tie your project in.
 
 ## Sponsors
 
+Thank you to these companies who believe in Nix as the future of software
+deployment for supporting the Nix Community at DEF CON:
+
+### Closure Tier
+
+>[![Flox](/img/sponsors/Flox.svg)](https://flox.dev)
+>[![Protectli](/img/sponsors/Protectli.png)](https://protectli.com/)
+
 Interested in sponsoring us with hardware, funding, or something else?
 Connect with us at <sponsor@nix.vegas>.
 


### PR DESCRIPTION
## Summary

Adds the first confirmed 2026 sponsors to the home-page (`content/2026/_index.md`) Sponsors section.

- **Flox** and **Protectli** displayed as **Closure Tier** sponsors — side-by-side as one centered logo row, reusing the existing `#sponsors ~ blockquote` styling and the logos already in `static/img/sponsors/`.
- Thank-you intro echoing 2025's wording (adjusted: dropped "first", since 2026 is the second year).
- The "interested in sponsoring" CTA now points to the Sponsorship Prospectus page (`/2026/sponsor`) alongside the contact email.

## Commits

1. `sponsors:` add Flox and Protectli as 2026 Closure Tier sponsors
2. `sponsors:` link the Sponsorship Prospectus from the home-page CTA

## Verification

- Clean `zola build`.
- Home page renders the `#sponsors` heading, the `Closure Tier` subheading, and both logos inside a `<blockquote>` (so the sponsor styling applies); both logo files are present in the build output.
- The prospectus link resolves to `/2026/sponsor`, whose page exists in the build output; the contact email still autolinks.
