### PR TITLE
Add Determinate Systems as a 2026 Closure Tier sponsor

### DIFF
--- a/content/2026/_index.md
+++ b/content/2026/_index.md
@@ -56,6 +56,7 @@ deployment for supporting the Nix Community at DEF CON:
 
 >[![Flox](/img/sponsors/Flox.svg)](https://flox.dev)
 >[![Protectli](/img/sponsors/Protectli.png)](https://protectli.com/)
+>[![Determinate Systems](/img/sponsors/Determinate.svg)](https://determinate.systems)
 
 Interested in sponsoring us with hardware, funding, or something else? See the
 [Sponsorship Prospectus](/2026/sponsor) and connect with us at


### PR DESCRIPTION
## Summary

- Adds Determinate Systems to the Closure Tier sponsors on the 2026 home page, using the existing logo at `static/img/sponsors/Determinate.svg` and linking https://determinate.systems (same logo/link as their 2025 sponsorship entry)
- Placed after Flox and Protectli, matching the order sponsors were added

Verified with `zola build`; the logo renders in the Closure Tier block. No conflict expected with #41 — its edits are in a different region of the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)