### PR TITLE
content/2026: onsite page (ported from 2025)

### DIFF
--- a/content/2026/onsite.md
+++ b/content/2026/onsite.md
@@ -8,6 +8,16 @@ title: "Onsite"
 We have every package from the [world's largest software repository](https://search.nixos.org)
 on machines here in this very room. Hopefully we've made it easy to get started.
 
+### On the network
+
+Once you're on our WiFi or plugged in, these all live on the event network:
+
+- **Binary cache** — [https://cache.nixos.lv](https://cache.nixos.lv) — every package we've
+  built and fetched, served locally ([how to use it](#downloading-packages-from-our-binary-cache)).
+- **Git server** — [https://git.nixos.lv](https://git.nixos.lv) — our Forgejo, mirroring nixpkgs
+  so you can browse and clone it at LAN speed.
+- **CTF** — [https://nixc.tf](https://nixc.tf) — capture the flag; the challenge VMs live here.
+
 ## Nixpkgs {{nixpkgsRev()}}
 
 We have a copy of [nixpkgs](https://github.com/nixpkgs), the world's largest and most up to date

--- a/content/2026/onsite.md
+++ b/content/2026/onsite.md
@@ -32,6 +32,9 @@ We use Let's Encrypt and pass through the ["official" Hydra binary cache key](ht
 so no more configuration is needed and you mostly don't have to trust us to serve you packages
 except for accepting that you'll need to hit our infra to download them.
 If you use the above version of nixpkgs, we will likely have what you want cached.
+If we don't, cache.nixos.lv fetches it from
+[https://cache.nixos.org](https://cache.nixos.org) for you on the fly and keeps a
+copy for the next person, so it only crosses the venue uplink once.
 
 You can use [https://search.nixos.org](https://search.nixos.org) or
 our local [nixos-pagefind](https://github.com/Jaculabilis/nixos-pagefind) built in the

--- a/content/2026/onsite.md
+++ b/content/2026/onsite.md
@@ -2,3 +2,69 @@
 template: "onsite.html"
 title: "Onsite"
 ---
+
+## Welcome to Nix Vegas
+
+We have every package from the [world's largest software repository](https://search.nixos.org)
+on machines here in this very room. Hopefully we've made it easy to get started.
+
+## Nixpkgs {{nixpkgsRev()}}
+
+We have a copy of [nixpkgs](https://github.com/nixpkgs), the world's largest and most up to date
+Linux package repository by [many measures](https://repology.org/repositories/graphs):
+
+- `nix-channel --remove nixpkgs`
+- <code>nix-channel --add {{nixpkgsUrl()}} nixpkgs</code>
+- `nix-channel --update`
+
+Our version is <code>{{nixpkgsVersion()}}</code>, which corresponds to <code>{{nixpkgsRev()}}</code> -
+click {{nixpkgsCommitLink(text="here")}} to see the corresponding commit on GitHub.
+
+### Downloading packages from our binary cache
+
+Our local binary cache is at [https://cache.nixos.lv](https://cache.nixos.lv). It serves
+everything we've built and fetched for the event, straight from our store over the
+event network. If you're using our channel:
+
+`nix-shell --option substituters https://cache.nixos.lv -p ghidra`
+
+We use Let's Encrypt and pass through the ["official" Hydra binary cache key](https://github.com/NixOS/nixpkgs/blob/nixos-26.05/nixos/modules/config/nix.nix),
+so no more configuration is needed and you mostly don't have to trust us to serve you packages
+except for accepting that you'll need to hit our infra to download them.
+If you use the above version of nixpkgs, we will likely have what you want cached.
+
+You can use [https://search.nixos.org](https://search.nixos.org) or
+our local [nixos-pagefind](https://github.com/Jaculabilis/nixos-pagefind) built in the
+[docs](#docs) section to find packages.
+
+### Trust but verify
+
+While you could just grab {{getNixpkgs(text="our nixpkgs")}} following the above instructions,
+you can also check that it's what we say it is yourself. (Installing random software at DEF CON
+seems like a great idea, right)?
+
+<code>diff -r $(nix-prefetch-url --print-path --unpack {{nixpkgsUrl()}} | tee /dev/stderr | tail -n1) $(nix-prefetch-url --print-path --unpack {{nixpkgsVerifyUrl()}} | tee /dev/stderr | tail -n1)</code>
+
+You should just see versions that differ.
+
+## NixOS {{ nixpkgsRev() }}
+
+You can also download our images that are configured to use https://cache.nixos.lv
+as their primary substituter to retrieve packages.
+
+### ISOs
+
+{{ nixosIsos() }}
+
+### Proxmox Images
+
+{{ nixosProxmoxImages() }}
+
+### Docs
+
+{{ nixosDocs() }}
+
+#### PXE boot your machine into NixOS
+
+Our DHCP servers all serve the same config as the above ISOs via NixOS netboot.
+Boot into PXE while plugged into one and you'll boot directly into NixOS.

--- a/content/2026/onsite.md
+++ b/content/2026/onsite.md
@@ -13,9 +13,10 @@ on machines here in this very room. Hopefully we've made it easy to get started.
 Once you're on our WiFi or plugged in, these all live on the event network:
 
 - **Binary cache** — [https://cache.nixos.lv](https://cache.nixos.lv) — every package we've
-  built and fetched, served locally ([how to use it](#downloading-packages-from-our-binary-cache)).
+  built and fetched, served locally, with **25.11, 26.05, and unstable** all cached
+  ([how to use it](#downloading-packages-from-our-binary-cache)).
 - **Git server** — [https://git.nixos.lv](https://git.nixos.lv) — our Forgejo, mirroring nixpkgs
-  so you can browse and clone it at LAN speed.
+  (25.11, 26.05, and unstable) so you can browse and clone at LAN speed.
 - **CTF** — [https://nixc.tf](https://nixc.tf) — capture the flag; the challenge VMs live here.
 
 ## Nixpkgs {{nixpkgsRev()}}

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782116945,
-        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
+        "lastModified": 1784011430,
+        "narHash": "sha256-lDebytrYdd47IBLwvNOD+6AGeoqZ78CIKlp70hzW280=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
+        "rev": "8eeec934ae0dbeca3d7868c059568a65c08b2fc3",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,8 @@
 
           packages = {
             default = pkgs.nix-vegas-site;
+            nixVegasOffsite = pkgs.nix-vegas-site;
+            nixVegasOnsite = pkgs.nix-vegas-site.onsite;
           };
 
           devShells.default = pkgs.mkShell {

--- a/pkgs/nix-vegas-site/default.nix
+++ b/pkgs/nix-vegas-site/default.nix
@@ -1,8 +1,9 @@
 {
   stdenv,
   zola,
+  callPackage,
   ...
-}:
+}@args:
 
 stdenv.mkDerivation {
   name = "nix-vegas-site";
@@ -21,4 +22,5 @@ stdenv.mkDerivation {
     mv public $out/
     runHook postInstall
   '';
+  passthru.onsite = callPackage ./onsite.nix args;
 }

--- a/pkgs/nix-vegas-site/onsite.nix
+++ b/pkgs/nix-vegas-site/onsite.nix
@@ -1,0 +1,50 @@
+{
+  nix-vegas-site,
+  jq,
+  yq,
+  emptyDirectory,
+  onboardingArtifacts ? emptyDirectory,
+  baseUrl ? "https://nixos.lv/",
+  ...
+}:
+
+nix-vegas-site.overrideAttrs (prev: {
+  inherit onboardingArtifacts;
+  nativeBuildInputs = prev.nativeBuildInputs or [ ] ++ [
+    yq
+    jq
+  ];
+  preBuild = ''
+    slurp_jq() {
+      jq --raw-input --slurp '(split("\n") | map(select(. != "")))'"$*"
+    }
+    ln -s $onboardingArtifacts nixos
+    tomlq -ti '.base_url = "${baseUrl}"' config.toml
+    tomlq -ti '.extra.onsite = true' config.toml
+    tomlq -ti ".extra.nixpkgs_rev = $({ cat nixos/rev || true; } | slurp_jq '[0] // ""')" config.toml
+    tomlq -ti ".extra.nixos_version = $({ cat nixos/version || true; } | slurp_jq '[0] // ""')" config.toml
+    tomlq -ti ".extra.isos = $(
+      { find -L nixos/systems/ -name '*.iso' || true; } | slurp_jq
+    )" config.toml
+    tomlq -ti ".extra.vmas = $(
+      { find -L nixos/systems/ -name '*.vma.zst' || true; } | slurp_jq
+    )" config.toml
+    tomlq -ti ".extra.manual = $(
+      { find -L nixos/manual/ -name index.html || true; } | slurp_jq '[0] // ""'
+    )" config.toml
+    tomlq -ti ".extra.search = $(
+      { find -L nixos/search/ -name index.html || true; } | slurp_jq '[0] // ""'
+    )" config.toml
+    tomlq -ti ".extra.channel = $(
+      { find -L nixos/channel/ -name '*.tar.xz' || true; } | slurp_jq '[0] // ""'
+    )" config.toml
+    rm -f nixos
+
+    echo "Final config.toml:" >&2
+    cat config.toml >&2
+  '';
+
+  postInstall = ''
+    ln -s $onboardingArtifacts $out/public/nixos
+  '';
+})

--- a/templates/onsite.html
+++ b/templates/onsite.html
@@ -1,5 +1,10 @@
 {% extends 'base.html' %}
 
 {% block content %}
-  {{ page.content | safe }}
+  {%- if config.extra.nixpkgs_rev -%}
+    {{ page.content | safe }}
+  {%- else -%}
+    <h2>This page is only available onsite.</h2>
+    <p>If you're already onsite, connect to the event network and go to <a href="https://nixos.lv">nixos.lv</a>.</p>
+  {%- endif -%}
 {% endblock %}

--- a/templates/shortcodes/getNixpkgs.html
+++ b/templates/shortcodes/getNixpkgs.html
@@ -6,4 +6,6 @@
       {{config.extra.channel | split(pat="/") | last}}
     {%- endif -%}
   </a>
+{%- else -%}
+  {%- if text -%}{{text}}{%- else -%}(onsite){%- endif -%}
 {%- endif -%}

--- a/templates/shortcodes/installNix.html
+++ b/templates/shortcodes/installNix.html
@@ -1,7 +1,9 @@
-<h4>Nixpkgs {{ config.nixos_version }}</h4>
+<h4>Nixpkgs {% if config.extra.nixos_version %}{{ config.extra.nixos_version }}{% else %}(onsite){% endif %}</h4>
 
-<ul>
 {% if config.extra.channel %}
-  <li><a href="/{{config.extra.channel}}">Nixpkgs channel</a> (<code> {{config.extra.nixpkgs_rev}}</code>)</li>
-{% endif %}
+<ul>
+  <li><a href="/{{config.extra.channel}}">Nixpkgs channel</a> (<code>{{config.extra.nixpkgs_rev}}</code>)</li>
 </ul>
+{% else %}
+<p><em>Available on the event network.</em></p>
+{% endif %}

--- a/templates/shortcodes/nixosDocs.html
+++ b/templates/shortcodes/nixosDocs.html
@@ -1,9 +1,12 @@
+{% if config.extra.manual or config.extra.search %}
 <ul>
 {% if config.extra.manual %}
   <li><a href="/{{ config.extra.manual }}">Manual</a></li>
 {% endif %}
-
 {% if config.extra.search %}
   <li><a href="/{{ config.extra.search }}">Search</a></li>
 {% endif %}
 </ul>
+{% else %}
+<p><em>Available on the event network.</em></p>
+{% endif %}

--- a/templates/shortcodes/nixosIsos.html
+++ b/templates/shortcodes/nixosIsos.html
@@ -1,5 +1,9 @@
+{% if config.extra.isos %}
 <ul>
   {% for iso_link in config.extra.isos %}
   <li><a href="/{{ iso_link }}">{{iso_link | split(pat="/") | last}}</a></li>
   {% endfor %}
 </ul>
+{% else %}
+<p><em>Available on the event network.</em></p>
+{% endif %}

--- a/templates/shortcodes/nixosProxmoxImages.html
+++ b/templates/shortcodes/nixosProxmoxImages.html
@@ -1,5 +1,9 @@
+{% if config.extra.vmas %}
 <ul>
-{% for vma_link in config.extra.vmas %}
+  {% for vma_link in config.extra.vmas %}
   <li><a href="/{{ vma_link }}">{{vma_link | split(pat="/") | last}}</a></li>
-{% endfor %}
+  {% endfor %}
 </ul>
+{% else %}
+<p><em>Available on the event network.</em></p>
+{% endif %}

--- a/templates/shortcodes/nixpkgsCommitLink.html
+++ b/templates/shortcodes/nixpkgsCommitLink.html
@@ -1,3 +1,4 @@
+{%- if config.extra.nixpkgs_rev -%}
 <a href="https://github.com/NixOS/nixpkgs/commit/{{ config.extra.nixpkgs_rev }}">
   {%- if text -%}
     {{text}}
@@ -5,3 +6,6 @@
     {{config.extra.nixpkgs_rev}}
   {%- endif -%}
 </a>
+{%- else -%}
+  {%- if text -%}{{text}}{%- else -%}(onsite){%- endif -%}
+{%- endif -%}

--- a/templates/shortcodes/nixpkgsRev.html
+++ b/templates/shortcodes/nixpkgsRev.html
@@ -1,1 +1,1 @@
-{{config.extra.nixpkgs_rev}}{%- set _ = "eat whitespace" -%}
+{%- if config.extra.nixpkgs_rev -%}{{config.extra.nixpkgs_rev}}{%- else -%}(onsite){%- endif -%}

--- a/templates/shortcodes/nixpkgsUrl.html
+++ b/templates/shortcodes/nixpkgsUrl.html
@@ -1,3 +1,5 @@
 {%- if config.extra.channel -%}
   {{config.base_url}}{{config.extra.channel}}
+{%- else -%}
+  (onsite)
 {%- endif -%}

--- a/templates/shortcodes/nixpkgsVerifyUrl.html
+++ b/templates/shortcodes/nixpkgsVerifyUrl.html
@@ -1,3 +1,5 @@
 {%- if config.extra.nixpkgs_rev -%}
   https://github.com/NixOS/nixpkgs/archive/{{config.extra.nixpkgs_rev}}.tar.gz
+{%- else -%}
+  (onsite)
 {%- endif -%}

--- a/templates/shortcodes/nixpkgsVersion.html
+++ b/templates/shortcodes/nixpkgsVersion.html
@@ -1,1 +1,1 @@
-{{ config.extra.nixos_version}}{%- set _ = "eat whitespace" -%}
+{%- if config.extra.nixos_version -%}{{ config.extra.nixos_version }}{%- else -%}(onsite){%- endif -%}


### PR DESCRIPTION
Bring back the optional rendering for ISOs and stuff.

Actual deployment: https://nixos.lv

PR to systems to update that config shortly after this merges